### PR TITLE
Easier form navigation

### DIFF
--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -268,6 +268,23 @@ NSTimer *durationTimer;
     return txt;
 }
 
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    // If this is the last object in the inputs array, resign first responder
+    // as the form is at the end.
+    if (textField == [_inputs lastObject]) {
+        [textField resignFirstResponder];
+    }
+    
+    // Otherwise find the next field and make it first responder.
+    else {
+        NSUInteger indexOfCurrentField = [_inputs indexOfObject:textField];
+        UITextField *nextField = _inputs[indexOfCurrentField + 1];
+        [nextField becomeFirstResponder];
+    }
+    
+    return NO;
+}
+
 #pragma mark - Buttons
 
 - (SCLButton *)addButton:(NSString *)title


### PR DESCRIPTION
This pull request makes navigation through SCLAlertView form fields easier and more user-friendly. Hitting return on a field will take users to the next field, made clear by setting the return-key type on the field to _Next_, and hitting return on the last field will dismiss the keyboard so users can see any buttons/the rest of the screen once they are done editing the form, made clear by setting the return-key type on the final field to _Done_.
