### PR TITLE
Minor icon and button customization fixes

### DIFF
--- a/SCLAlertView/SCLAlertView.h
+++ b/SCLAlertView/SCLAlertView.h
@@ -156,6 +156,12 @@ typedef NS_ENUM(NSInteger, SCLAlertViewBackground)
  */
 @property (nonatomic, strong) UIColor *backgroundViewColor;
 
+/** Set custom tint color for icon image.
+ *
+ * SCLAlertView icon tint color
+ */
+@property (nonatomic, strong) UIColor *iconTintColor;
+
 /** Warns that alerts is gone
  *
  * Warns that alerts is gone using block

--- a/SCLAlertView/SCLAlertView.h
+++ b/SCLAlertView/SCLAlertView.h
@@ -108,12 +108,19 @@ typedef NS_ENUM(NSInteger, SCLAlertViewBackground)
  */
 @property (nonatomic, copy) SCLAttributedFormatBlock attributedFormatBlock;
 
-/** Set button format block.
+/** Set Complete button format block.
  *
  * Holds the button format block. 
- * Support keys : backgroundColor, textColor
+ * Support keys : backgroundColor, borderColor, textColor
  */
 @property (nonatomic, copy) CompleteButtonFormatBlock completeButtonFormatBlock;
+
+/** Set button format block.
+ *
+ * Holds the button format block.
+ * Support keys : backgroundColor, borderColor, textColor
+ */
+@property (nonatomic, copy) ButtonFormatBlock buttonFormatBlock;
 
 /** Hide animation type
  *

--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -766,7 +766,11 @@ NSTimer *durationTimer;
     }
     else
     {
-        self.circleIconImageView.image  = iconImage;
+        if (self.iconTintColor) {
+            self.circleIconImageView.tintColor = self.iconTintColor;
+            iconImage  = [iconImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        }
+        self.circleIconImageView.image = iconImage;
     }
     
     for (UITextField *textField in _inputs)

--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -770,6 +770,11 @@ NSTimer *durationTimer;
     
     for (SCLButton *btn in _buttons)
     {
+        if (style == Warning)
+        {
+            [btn setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+        }
+        
         if (btn.completeButtonFormatBlock != nil)
         {
             [btn parseConfig:btn.completeButtonFormatBlock()];
@@ -781,10 +786,6 @@ NSTimer *durationTimer;
         else
         {
             btn.defaultBackgroundColor = viewColor;
-        }
-        if (style == Warning)
-        {
-            [btn setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
         }
     }
     

--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -529,6 +529,12 @@ NSTimer *durationTimer;
 - (SCLButton *)addButton:(NSString *)title actionBlock:(SCLActionBlock)action
 {
     SCLButton *btn = [self addButton:title];
+    
+    if (_buttonFormatBlock != nil)
+    {
+        btn.buttonFormatBlock = _buttonFormatBlock;
+    }
+    
     btn.actionType = Block;
     btn.actionBlock = action;
     [btn addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
@@ -774,6 +780,7 @@ NSTimer *durationTimer;
         {
             [btn setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
         }
+        btn.defaultBackgroundColor = viewColor;
         
         if (btn.completeButtonFormatBlock != nil)
         {
@@ -782,10 +789,6 @@ NSTimer *durationTimer;
         else if (btn.buttonFormatBlock != nil)
         {
             [btn parseConfig:btn.buttonFormatBlock()];
-        }
-        else
-        {
-            btn.defaultBackgroundColor = viewColor;
         }
     }
     


### PR DESCRIPTION
I've found that button configuration (especially for textColor) is not applied for alerts with Warning style set.
Also I've missed option to customize color of the default icons.