### PR TITLE
Automatically add a borderWidth to the button if borderColor is defined

### DIFF
--- a/SCLAlertView/SCLButton.m
+++ b/SCLAlertView/SCLButton.m
@@ -67,6 +67,7 @@
     if (buttonConfig[@"borderColor"])
     {
         self.layer.borderColor = ((UIColor*)buttonConfig[@"borderColor"]).CGColor;
+        self.layer.borderWidth = self.layer.borderWidth ?: 2.0f;
     }
     if (buttonConfig[@"textColor"])
     {

--- a/SCLAlertViewExample/ViewController.m
+++ b/SCLAlertViewExample/ViewController.m
@@ -140,6 +140,7 @@ NSString *kAttributeTitle = @"Attributed string operation successfully completed
         NSMutableDictionary *buttonConfig = [[NSMutableDictionary alloc] init];
         
         buttonConfig[@"backgroundColor"] = [UIColor greenColor];
+        buttonConfig[@"borderColor"] = [UIColor blackColor];
         buttonConfig[@"textColor"] = [UIColor blackColor];
         
         return buttonConfig;


### PR DESCRIPTION
Otherwise the borderColor for the completeButtonFormatBlock is totally useless. Thanks. ;)