### PR TITLE
fix screen stutter glitch with blur background

### DIFF
--- a/SCLAlertView/UIImage+ImageEffects.m
+++ b/SCLAlertView/UIImage+ImageEffects.m
@@ -312,7 +312,7 @@
     {
         //Optimized/fast method for rendering a UIView as image on iOS 7 and later versions.
         UIGraphicsBeginImageContextWithOptions(view.bounds.size, YES, scale);
-        [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
+        [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:NO];
         capturedScreen = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
     }


### PR DESCRIPTION

![alert_stutter](https://cloud.githubusercontent.com/assets/1863251/6941261/aa93f57c-d854-11e4-9297-b6d5425fe524.gif)

When adding a blurred background this method would apply the image to the original view which would be displayed for a fraction of a second before the blurred background image was applied. This would cause a stutter in the background view