### PR TITLE
Fix Crash for iOS 7

### DIFF
--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -1012,7 +1012,7 @@ NSTimer *durationTimer;
 
 - (BOOL)isAppExtension
 {
-    return [[[NSBundle mainBundle] executablePath] containsString:@".appex/"];
+    return [[[NSBundle mainBundle] executablePath] rangeOfString:@".appex/"].location != NSNotFound;
 }
 
 #pragma mark - Background Effects


### PR DESCRIPTION
Commit https://github.com/dogo/SCLAlertView/commit/cb53c9404c6a2636dd4277bbd16738baf22cdc64 causes this to crash on iOS 7 because the `containsString` method is only on iOS 8. This works on both iOS 7 and iOS 8