### PR TITLE
Feature/countdown timer

### DIFF
--- a/SCLAlertView.xcodeproj/project.pbxproj
+++ b/SCLAlertView.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		572BB1471B8383B3002DEE38 /* SCLTimerDisplay.m in Sources */ = {isa = PBXBuildFile; fileRef = 572BB1461B8383B3002DEE38 /* SCLTimerDisplay.m */; };
 		DD2E172A19FA84B800CBAEC3 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = DD2E172919FA84B800CBAEC3 /* UIImage+ImageEffects.m */; };
 		DD4BA9C119DED8EF008D73EB /* right_answer.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = DD4BA9C019DED8EF008D73EB /* right_answer.mp3 */; };
 		DD7282B919D6087C00077F54 /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD7282B719D6087C00077F54 /* Storyboard.storyboard */; };
@@ -32,6 +33,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		572BB1451B8383B3002DEE38 /* SCLTimerDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCLTimerDisplay.h; sourceTree = "<group>"; };
+		572BB1461B8383B3002DEE38 /* SCLTimerDisplay.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCLTimerDisplay.m; sourceTree = "<group>"; };
 		DD0D295B19D902DA00881F53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = SCLAlertViewExample/Info.plist; sourceTree = SOURCE_ROOT; };
 		DD2E172819FA84B800CBAEC3 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ImageEffects.h"; sourceTree = "<group>"; };
 		DD2E172919FA84B800CBAEC3 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ImageEffects.m"; sourceTree = "<group>"; };
@@ -162,6 +165,8 @@
 				DDB15FDF19D5D85B00173158 /* SCLAlertViewStyleKit.h */,
 				DDB15FE019D5D85B00173158 /* SCLAlertViewStyleKit.m */,
 				DD2F03171AAFA4E0007BC507 /* SCLMacros.h */,
+				572BB1451B8383B3002DEE38 /* SCLTimerDisplay.h */,
+				572BB1461B8383B3002DEE38 /* SCLTimerDisplay.m */,
 			);
 			path = SCLAlertView;
 			sourceTree = "<group>";
@@ -270,6 +275,7 @@
 				DDB15FCB19D5B88A00173158 /* ViewController.m in Sources */,
 				DDB15FD419D5B8DB00173158 /* main.m in Sources */,
 				DDB15FE119D5D85B00173158 /* SCLAlertViewStyleKit.m in Sources */,
+				572BB1471B8383B3002DEE38 /* SCLTimerDisplay.m in Sources */,
 				DDB15FD719D5B96500173158 /* SCLAlertView.m in Sources */,
 				DDB15FDB19D5BAA000173158 /* SCLButton.m in Sources */,
 				DDB15FCA19D5B88A00173158 /* AppDelegate.m in Sources */,

--- a/SCLAlertView/SCLAlertView.h
+++ b/SCLAlertView/SCLAlertView.h
@@ -220,6 +220,12 @@ typedef NS_ENUM(NSInteger, SCLAlertViewBackground)
  */
 - (void)addCustomTextField:(UITextField *)textField;
 
+/** Add Timer Display
+ *
+ * @param buttonIndex The index of the button to add the timer display to.
+ */
+- (void)addTimerToButton:(NSInteger)buttonIndex;
+
 /** Set SubTitle Height
  *
  * @deprecated Deprecated since 0.5.2+ .

--- a/SCLAlertView/SCLButton.h
+++ b/SCLAlertView/SCLButton.h
@@ -12,6 +12,8 @@
 #import <UIKit/UIKit.h>
 #endif
 
+@class SCLTimerDisplay;
+
 @interface SCLButton : UIButton
 
 typedef void (^SCLActionBlock)(void);
@@ -84,5 +86,11 @@ typedef NS_ENUM(NSInteger, SCLActionType)
  * Set keys : backgroundColor, borderWidth, borderColor, textColor
  */
 - (void)parseConfig:(NSDictionary *)buttonConfig;
+
+/** Set button timer.
+ *
+ * Holds the button timer, if present.
+ */
+@property (nonatomic) SCLTimerDisplay *timer;
 
 @end

--- a/SCLAlertView/SCLButton.m
+++ b/SCLAlertView/SCLButton.m
@@ -7,6 +7,7 @@
 //
 
 #import "SCLButton.h"
+#import "SCLTimerDisplay.h"
 
 #define MIN_HEIGHT 35.0f
 
@@ -70,6 +71,14 @@
 - (void)setDefaultBackgroundColor:(UIColor *)defaultBackgroundColor
 {
     self.backgroundColor = _defaultBackgroundColor = defaultBackgroundColor;
+}
+
+- (void)setTimer:(SCLTimerDisplay *)timer
+{
+    _timer = timer;
+    [self addSubview:timer];
+    [timer updateFrame:self.frame.size];
+    timer.color = self.titleLabel.textColor;
 }
 
 #pragma mark - Button Apperance

--- a/SCLAlertView/SCLTimerDisplay.h
+++ b/SCLAlertView/SCLTimerDisplay.h
@@ -1,0 +1,34 @@
+//
+//  SCLTimerDisplay.h
+//  SCLAlertView
+//
+//  Created by Taylor Ryan on 8/18/15.
+//  Copyright (c) 2015 AnyKey Entertainment. All rights reserved.
+//
+//  Taken from https://stackoverflow.com/questions/11783439/uibutton-with-timer
+
+#import <UIKit/UIKit.h>
+#import "SCLButton.h"
+
+@interface SCLTimerDisplay : UIView{
+    CGFloat currentAngle;
+    CGFloat currentTime;
+    CGFloat timerLimit;
+    CGFloat radius;
+    CGFloat lineWidth;
+    NSTimer *timer;
+    SCLActionBlock completedBlock;
+}
+
+@property CGFloat currentAngle;
+@property (nonatomic) UIColor *color;
+@property NSInteger buttonIndex;
+
+- (instancetype)initWithOrigin:(CGPoint)origin radius:(CGFloat)r;
+- (instancetype)initWithOrigin:(CGPoint)origin radius:(CGFloat)r lineWidth:(CGFloat)width;
+- (void)updateFrame:(CGSize)size;
+- (void)cancelTimer;
+- (void)stopTimer;
+- (void)startTimerWithTimeLimit:(int)tl completed:(SCLActionBlock)completed;
+
+@end

--- a/SCLAlertView/SCLTimerDisplay.m
+++ b/SCLAlertView/SCLTimerDisplay.m
@@ -1,0 +1,102 @@
+//
+//  SCLTimerDisplay.m
+//  SCLAlertView
+//
+//  Created by Taylor Ryan on 8/18/15.
+//  Copyright (c) 2015 AnyKey Entertainment. All rights reserved.
+//
+
+#import "SCLTimerDisplay.h"
+
+@implementation SCLTimerDisplay
+
+#define DEGREES_TO_RADIANS(degrees)  ((M_PI * degrees)/ 180)
+#define TIMER_STEP .01
+#define START_DEGREE_OFFSET -90
+
+@synthesize currentAngle;
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self)
+    {
+        self.backgroundColor = [UIColor clearColor];
+        currentAngle = 0;
+    }
+    return self;
+}
+
+- (instancetype)initWithOrigin:(CGPoint)origin radius:(CGFloat)r
+{
+    return [self initWithOrigin:(CGPoint)origin radius:r lineWidth:5];
+}
+
+- (instancetype)initWithOrigin:(CGPoint)origin radius:(CGFloat)r lineWidth:(CGFloat)width
+{
+    self = [super initWithFrame:CGRectMake(origin.x, origin.y, r*2, r*2)];
+    if (self) {
+        self.backgroundColor = [UIColor clearColor];
+        currentAngle = START_DEGREE_OFFSET;
+        radius = r-(width/2);
+        lineWidth = width;
+        self.color = [UIColor whiteColor];
+        self.userInteractionEnabled = NO;
+    }
+    return self;
+}
+
+- (void)updateFrame:(CGSize)size
+{
+    CGFloat r = radius+(lineWidth/2);
+    
+    CGFloat originX = size.width - (2*r) - 5;
+    CGFloat originY = (size.height - (2*r))/2;
+    
+    self.frame = CGRectMake(originX, originY, r*2, r*2);
+}
+
+- (void)drawRect:(CGRect)rect
+{
+    UIBezierPath* aPath = [UIBezierPath bezierPathWithArcCenter:CGPointMake(radius+(lineWidth/2), radius+(lineWidth/2))
+                                                         radius:radius
+                                                     startAngle:DEGREES_TO_RADIANS(START_DEGREE_OFFSET)
+                                                       endAngle:DEGREES_TO_RADIANS(currentAngle)
+                                                      clockwise:YES];
+    [self.color setStroke];
+    aPath.lineWidth = lineWidth;
+    [aPath stroke];
+}
+
+-(void)startTimerWithTimeLimit:(int)tl completed:(SCLActionBlock)completed
+{
+    timerLimit = tl;
+    timer = [NSTimer scheduledTimerWithTimeInterval:TIMER_STEP target:self selector:@selector(updateTimerButton:) userInfo:nil repeats:YES];
+    completedBlock = completed;
+}
+
+-(void)cancelTimer
+{
+    [timer invalidate];
+}
+
+-(void)stopTimer
+{
+    [timer invalidate];
+    if (completedBlock != nil) {
+        completedBlock();
+    }
+}
+
+-(void)updateTimerButton:(NSTimer *)timer
+{
+    currentTime += TIMER_STEP;
+    currentAngle = (currentTime/timerLimit) * 360 + START_DEGREE_OFFSET;
+    
+    if(currentAngle >= (360+START_DEGREE_OFFSET)){
+        [self stopTimer];
+    }
+    [self setNeedsDisplay];
+}
+
+@end

--- a/SCLAlertViewExample/Base.lproj/Storyboard.storyboard
+++ b/SCLAlertViewExample/Base.lproj/Storyboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Ohq-jH-G4R">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Ohq-jH-G4R">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -128,6 +128,18 @@
                                     <action selector="showWaiting:" destination="Ohq-jH-G4R" eventType="touchUpInside" id="ler-Oz-x3u"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Leu-lo-T4a">
+                                <rect key="frame" x="202" y="454" width="196" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="196" id="l7J-oT-3CH"/>
+                                </constraints>
+                                <state key="normal" title="Show Countdown Timer">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="showCountdown:" destination="Ohq-jH-G4R" eventType="touchUpInside" id="m2j-hh-ctl"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -146,6 +158,7 @@
                             <constraint firstItem="mww-Jw-0ao" firstAttribute="leading" secondItem="cKc-Im-7MS" secondAttribute="leading" constant="-1" id="Wzq-tH-GyX"/>
                             <constraint firstItem="cKc-Im-7MS" firstAttribute="top" secondItem="c2J-Bd-hKP" secondAttribute="bottom" constant="8" symbolic="YES" id="XWK-92-ETT"/>
                             <constraint firstItem="cKc-Im-7MS" firstAttribute="centerX" secondItem="c2J-Bd-hKP" secondAttribute="centerX" constant="-1.5" id="YDy-yh-6BI"/>
+                            <constraint firstItem="Leu-lo-T4a" firstAttribute="top" secondItem="fs5-sr-WWC" secondAttribute="bottom" constant="8" symbolic="YES" id="cbb-tc-6jE"/>
                             <constraint firstItem="c2J-Bd-hKP" firstAttribute="top" secondItem="QYK-Po-EUn" secondAttribute="bottom" constant="8" symbolic="YES" id="d5O-cr-EFD"/>
                             <constraint firstItem="4U1-31-wBg" firstAttribute="centerX" secondItem="QYK-Po-EUn" secondAttribute="centerX" constant="-1.5" id="e52-ij-sMi"/>
                             <constraint firstItem="mww-Jw-0ao" firstAttribute="top" secondItem="cKc-Im-7MS" secondAttribute="bottom" constant="8" symbolic="YES" id="ffc-Hg-N85"/>
@@ -154,6 +167,7 @@
                             <constraint firstItem="DRS-IB-vIQ" firstAttribute="top" secondItem="w0L-ki-asc" secondAttribute="bottom" constant="8" symbolic="YES" id="nid-zP-8tX"/>
                             <constraint firstItem="XBG-LD-1eZ" firstAttribute="top" secondItem="DRS-IB-vIQ" secondAttribute="bottom" constant="8" symbolic="YES" id="r6L-Qc-xuP"/>
                             <constraint firstItem="8ID-0w-GrU" firstAttribute="centerX" secondItem="mww-Jw-0ao" secondAttribute="centerX" constant="1.5" id="tef-Wd-z5m"/>
+                            <constraint firstAttribute="centerX" secondItem="Leu-lo-T4a" secondAttribute="centerX" id="uaY-f6-Mq9"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/SCLAlertViewExample/ViewController.m
+++ b/SCLAlertViewExample/ViewController.m
@@ -55,10 +55,10 @@ NSString *kAttributeTitle = @"Attributed string operation successfully completed
     [alert addButton:@"Second Button" actionBlock:^(void) {
         NSLog(@"Second button tapped");
     }];
-    
+    [alert addTimerToButton:0];
     alert.soundURL = [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/right_answer.mp3", [[NSBundle mainBundle] resourcePath]]];
 
-    [alert showSuccess:kSuccessTitle subTitle:kSubtitle closeButtonTitle:kButtonTitle duration:0.0f];
+    [alert showSuccess:kSuccessTitle subTitle:kSubtitle closeButtonTitle:kButtonTitle duration:10.0f];
 }
 
 - (IBAction)showError:(id)sender
@@ -244,6 +244,15 @@ NSString *kAttributeTitle = @"Attributed string operation successfully completed
     [alert showWaiting:self title:@"Waiting..."
             subTitle:@"You've just displayed this awesome Pop Up View with transparent background"
     closeButtonTitle:nil duration:5.0f];
+}
+
+- (IBAction)showCountdown:(id)sender
+{
+    SCLAlertView *alert = [[SCLAlertView alloc] init];
+    [alert addTimerToButton:0];
+    [alert showInfo:self title:@"Countdown Timer"
+            subTitle:@"This alert has a duration set, and a countdown timer on the Dismiss button to show how long is left."
+    closeButtonTitle:@"Dismiss" duration:10.0f];
 }
 
 - (void)firstButton


### PR DESCRIPTION
This is based on the request in #113. It implements support for adding a countdown timer (similar to Waze) for a single given button. The user passes addTimerToButton: a buttonIndex (0 being the top most button) and when the alert is displayed, and has a duration configured, the countdown timer will display. After the timer winds down, the button for which the timer is on is effectively tapped, triggering any validate / action that may be configured for it. The timer color is the same as the button text, so it should always be visible, given the text is.

Currently the timer displays on the right side of the button, centered vertically. I have not looked into providing an option for it to be on the left, though i imagine it wouldn't be that difficult. Also, I did not check how the timer looks if the button title text is very long.