### PR TITLE
Prevent viewText scrollable

### DIFF
--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -230,6 +230,7 @@ SCLTimerDisplay *buttonTimer;
     {
         _viewText.textContainerInset = UIEdgeInsetsZero;
         _viewText.textContainer.lineFragmentPadding = 0;
+        self.automaticallyAdjustsScrollViewInsets = NO;
     }
     
     // Colors


### PR DESCRIPTION
When showEdit with a navigation controller and having an empty string
title, the viewText’s insets were automatically adjusted so it becoming
scrollable.