### PR TITLE
Change play sound class

### DIFF
--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -55,6 +55,8 @@
 @property (nonatomic) CGFloat windowWidth;
 @property (nonatomic) CGFloat subTitleHeight;
 @property (nonatomic) CGFloat subTitleY;
+/** soundID */
+@property(nonatomic,assign) SystemSoundID soundID;
 
 @end
 
@@ -468,7 +470,20 @@ SCLTimerDisplay *buttonTimer;
 {
     NSError *error;
     _soundURL = soundURL;
-    _audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:_soundURL error:&error];
+    //_audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:_soundURL error:&error];
+    
+    //DisposeSound
+    AudioServicesDisposeSystemSoundID(_soundID);
+
+    AudioServicesCreateSystemSoundID((__bridge CFURLRef)_soundURL,&_soundID);
+    
+    AudioServicesPlaySystemSoundWithCompletion(_soundID, ^{
+        //call When Sound play to the end
+        
+    });
+
+    //PlaySound
+    AudioServicesPlaySystemSound(_soundID);
 }
 
 #pragma mark - Subtitle Height


### PR DESCRIPTION
Hello,First of all I wanna say "I Love SCLAlertView!".I find a issue. When you are listening music,you display SCLAlertView which one with sound at another APP,then the music would stop. I used `AudioServicesPlaySystemSound(_soundID)` play sound,fixed this issue.  I think AudioServicesPlaySystemSound play sounds would be better,cuz the sound is short. My English is not good,hopefully you get my words. Thanks.