### PR TITLE
Adds show/hide AnimationTypes 'SimplyAppear' and 'SimplyDisappear' i.e., 'None'

### DIFF
--- a/SCLAlertView/SCLAlertView.h
+++ b/SCLAlertView/SCLAlertView.h
@@ -50,7 +50,8 @@ typedef NS_ENUM(NSInteger, SCLAlertViewHideAnimation)
     SlideOutToLeft,
     SlideOutToRight,
     SlideOutToCenter,
-    SlideOutFromCenter
+    SlideOutFromCenter,
+    SimplyDisappear
 };
 
 /** Alert show animation styles
@@ -65,7 +66,8 @@ typedef NS_ENUM(NSInteger, SCLAlertViewShowAnimation)
     SlideInFromLeft,
     SlideInFromRight,
     SlideInFromCenter,
-    SlideInToCenter
+    SlideInToCenter,
+    SimplyAppear
 };
 
 /** Alert background styles

--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -1245,6 +1245,10 @@ SCLTimerDisplay *buttonTimer;
         case SlideInToCenter:
             [self slideInToCenter];
             break;
+            
+        case SimplyAppear:
+            [self simplyAppear];
+            break;
     }
 }
 
@@ -1280,6 +1284,10 @@ SCLTimerDisplay *buttonTimer;
             
         case SlideOutFromCenter:
             [self slideOutFromCenter];
+            break;
+        
+        case SimplyDisappear:
+            [self simplyDisappear];
             break;
     }
     
@@ -1398,6 +1406,18 @@ SCLTimerDisplay *buttonTimer;
         [self fadeOut];
     }];
 }
+
+- (void)simplyDisappear
+{
+    self.backgroundView.alpha = _backgroundOpacity;
+    self.view.alpha = 1.0f;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self.backgroundView.alpha = 0.0f;
+        self.view.alpha = 0.0f;
+    });
+}
+
 
 #pragma mark - Show Animations
 
@@ -1571,6 +1591,18 @@ SCLTimerDisplay *buttonTimer;
         }];
     }];
 }
+
+- (void)simplyAppear
+{
+    self.backgroundView.alpha = 0.0f;
+    self.view.alpha = 0.0f;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self.backgroundView.alpha = _backgroundOpacity;
+        self.view.alpha = 1.0f;
+    });
+}
+
 
 @end
 

--- a/SCLAlertViewExample/ViewController.m
+++ b/SCLAlertViewExample/ViewController.m
@@ -84,7 +84,7 @@ NSString *kAttributeTitle = @"Attributed string operation successfully completed
     SCLAlertView *alert = [[SCLAlertView alloc] init];
     
     alert.backgroundType = Blur;
-    
+    alert.showAnimationType = FadeIn;
     [alert showNotice:self title:kNoticeTitle subTitle:@"You've just displayed this awesome Pop Up View with blur effect" closeButtonTitle:kButtonTitle duration:0.0f];
 }
 
@@ -100,7 +100,7 @@ NSString *kAttributeTitle = @"Attributed string operation successfully completed
     SCLAlertView *alert = [[SCLAlertView alloc] init];
     
     alert.shouldDismissOnTapOutside = YES;
-    
+    alert.showAnimationType = SimplyAppear;
     [alert alertIsDismissed:^{
         NSLog(@"SCLAlertView dismissed!");
     }];
@@ -113,7 +113,7 @@ NSString *kAttributeTitle = @"Attributed string operation successfully completed
     SCLAlertView *alert = [[SCLAlertView alloc] init];
     
     SCLTextView *textField = [alert addTextField:@"Enter your name"];
-    
+    alert.hideAnimationType = SimplyDisappear;
     [alert addButton:@"Show Name" actionBlock:^(void) {
         NSLog(@"Text value: %@", textField.text);
     }];


### PR DESCRIPTION
I needed an alert without a grand animated entrance, and put it in. 

Regarding the nomenclature, I would have called the type `None`, but that caused a conflict between the hide and show versions (illegal redefinition etc. etc.), and `SCLAlertViewHideAnimationTypeNone` and `SCLAlertViewShowAnimationTypeNone` seemed a bit verbose to me, even in a Cocoa environment.