### PR TITLE
docs: nativescript integration mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,15 @@ To install add the following line to your Podfile:
 ### Collaboration
 I tried to build an easy to use API, while beeing flexible enough for multiple variations, but I'm sure there are ways of improving and adding more features, so feel free to collaborate with ideas, issues and/or pull requests.
 
-###Incoming improvements
+### Incoming improvements
 - More animations
 - Performance tests
 - Remove some hardcode values
+
+### Plugin integrations
+
+- [nativescript-fancyalert for NativeScript](https://github.com/NathanWalker/nativescript-fancyalert)
+  - Use SCLAlertView with [NativeScript](https://www.nativescript.org/)
 
 ### Thanks to the original team
 - Design [@SherzodMx](https://twitter.com/SherzodMx) Sherzod Max


### PR DESCRIPTION
Thanks for this excellent CocoaPod! It is now available for use with [NativeScript](https://github.com/NathanWalker/nativescript-fancyalert); just adds a small mention in the README.