### PR TITLE
Added missing setter in SCLSwitchView

### DIFF
--- a/SCLAlertView/SCLSwitchView.m
+++ b/SCLAlertView/SCLSwitchView.m
@@ -132,4 +132,9 @@
     self.switchLabel.text = labelText;
 }
 
+- (void)setSelected:(BOOL)selected
+{
+    self.switchKnob.on = selected;
+}
+
 @end


### PR DESCRIPTION
###### Fixes issue #.
- [x] This pull request follows the coding standards

###### This PR changes:
 - 
Is impossible to set the initial state of the switch if you don't have the setter