### PR TITLE
Change auto-capitalisation to sentence only

### DIFF
--- a/SCLAlertView/SCLTextView.m
+++ b/SCLAlertView/SCLTextView.m
@@ -47,7 +47,7 @@
     self.frame = CGRectMake(0.0f, 0.0f, 0.0f, MIN_HEIGHT);
     self.returnKeyType = UIReturnKeyDone;
     self.borderStyle = UITextBorderStyleRoundedRect;
-    self.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    self.autocapitalizationType = UITextAutocapitalizationTypeSentences;
     self.clearButtonMode = UITextFieldViewModeWhileEditing;
     self.layer.masksToBounds = YES;
     self.layer.borderWidth = 1.0f;


### PR DESCRIPTION
###### Fixes issue #.
- [X] This pull request follows the coding standards

###### This PR changes:
Change auto-capitalisation of input textfield to only capitalise first letter of a sentence instead of first letter of each word.
This is default behaviour for other input views in iOS and therefore shouldn't bother the user as much.