### PR TITLE
Fix an issue with black screen after showing alert 

### DIFF
--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -1203,7 +1203,7 @@ SCLTimerDisplay *buttonTimer;
 
 - (void)makeBlurBackground
 {
-    UIView *appView = (_usingNewWindow) ? [UIApplication sharedApplication].keyWindow.subviews.lastObject : _rootViewController.view;
+    UIView *appView = (_usingNewWindow) ? [UIApplication sharedApplication].keyWindow : _rootViewController.view;
     UIImage *image = [UIImage convertViewToImage:appView];
     UIImage *blurSnapshotImage = [image applyBlurWithRadius:5.0f
                                                   tintColor:[UIColor colorWithWhite:0.2f


### PR DESCRIPTION
Fix an issue with black screen after showing alert because of snapshotting only the last subview of the key window

###### Fixes issue #.
- [ ] This pull request follows the coding standards

###### This PR changes:
 - 