### PR TITLE
Fix race condition in keyboard hide animation

### DIFF
--- a/SCLAlertView/SCLAlertView.m
+++ b/SCLAlertView/SCLAlertView.m
@@ -721,6 +721,8 @@ SCLTimerDisplay *buttonTimer;
         NSTimeInterval animationDuration = [userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
         UIViewAnimationOptions animationCurve = [userInfo[UIKeyboardAnimationCurveUserInfoKey] unsignedIntegerValue] << 16;
 
+        _keyboardIsVisible = NO;
+        
         [UIView animateWithDuration:animationDuration delay:0 options:animationCurve animations:^{
             CGRect contentFrame = self.contentView.frame;
             contentFrame.origin.y = self->_tmpContentViewFrameOrigin.y;
@@ -730,11 +732,12 @@ SCLTimerDisplay *buttonTimer;
             circleFrame.origin.y = self->_tmpCircleViewFrameOrigin.y;
             self.circleViewBackground.frame = circleFrame;
         } completion:^(BOOL finished) {
-            self->_tmpContentViewFrameOrigin = CGPointZero;
-            self->_tmpCircleViewFrameOrigin = CGPointZero;
+            // Only reset if keyboard hasn't been shown again during the animation
+            if (!self->_keyboardIsVisible) {
+                self->_tmpContentViewFrameOrigin = CGPointZero;
+                self->_tmpCircleViewFrameOrigin = CGPointZero;
+            }
         }];
-
-        _keyboardIsVisible = NO;
     }
 }
 


### PR DESCRIPTION
Guard temp value reset in completion block to prevent corruption when keyboard is shown again during hide animation.

###### Fixes issue #.
- [x] This pull request follows the coding standards

###### This PR changes:

Guard temp value reset in completion block to prevent corruption when
keyboard is shown again during hide animation.